### PR TITLE
Fix error with callGraphSnapshotAPIResult

### DIFF
--- a/src/scripts/datadog-graph.coffee
+++ b/src/scripts/datadog-graph.coffee
@@ -66,8 +66,8 @@ module.exports = (robot) ->
     start = moment(e).subtract(number, unit).format('X')
     end = e.format('X')
 
-    callGraphSnapshotAPI query, start, end
-    .then (json) ->
+    callGraphSnapshotAPIResult = callGraphSnapshotAPI query, start, end
+    callGraphSnapshotAPIResult.then (json) ->
       setTimeout (-> res.send json.snapshot_url), config.wait
     .catch (e) ->
       res.robot.logger.error e


### PR DESCRIPTION
E.g.:

```
breakbot> breakbot datadog graph sushi
breakbot> [Tue Jul 12 2016 11:22:31 GMT-0700 (PDT)] ERROR TypeError: end.then is not a function
  at TextListener.callback (/Users/solarh/breakbot/scripts/datadog-graph.coffee:69:5, <js>:70:53)
  at executeListener (/Users/solarh/breakbot/node_modules/hubot/src/listener.coffee:65:11, <js>:53:19)
  at allDone (/Users/solarh/breakbot/node_modules/hubot/src/middleware.coffee:44:37, <js>:34:16)
  at /Users/solarh/breakbot/node_modules/async/lib/async.js:274:13
  at Object.async.eachSeries (/Users/solarh/breakbot/node_modules/async/lib/async.js:142:20)
  at Object.async.reduce (/Users/solarh/breakbot/node_modules/async/lib/async.js:268:15)
  at /Users/solarh/breakbot/node_modules/hubot/src/middleware.coffee:49:7, <js>:37:22
  at _combinedTickCallback (internal/process/next_tick.js:67:7)
  at process._tickCallback (internal/process/next_tick.js:98:9)
```
